### PR TITLE
Style/navbar colors

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -23,7 +23,11 @@ const Navbar = () => {
   }, []);
 
   return (
-    <nav className={`${styles.navbar} ${isScrolled ? styles.scrolled : ""}`}>
+    <nav
+      className={`${styles.navbar} ${!isScrolled ? styles.fixed : ""} ${
+        isScrolled ? styles.scrolled : ""
+      }`}
+    >
       <div className={styles["navbar-content"]}>
         <div className={styles["navbar-logo"]}>
           <a href="/">

--- a/src/components/Navbar/navbar.module.css
+++ b/src/components/Navbar/navbar.module.css
@@ -23,6 +23,18 @@
   border-bottom: 1px solid rgba(206, 212, 218, 0.6);
 }
 
+.navbar.fixed {
+  background: #b91c1c;
+}
+
+.navbar.fixed .navbar-links li a {
+  color: #fff;
+}
+
+.navbar.fixed .navbar-links li a:hover {
+  color: #fff;
+}
+
 .navbar-content {
   display: flex;
   align-items: center;
@@ -144,4 +156,12 @@
   .navbar-links li a {
     display: block;
   }
+}
+
+.navbar.fixed .navbar-links li a::after {
+  background: #f59e42;
+}
+
+.navbar.fixed .navbar-logo img {
+  filter: brightness(1.25) drop-shadow(0 1px 6px rgba(0, 0, 0, 0.18));
 }


### PR DESCRIPTION
Ajusta a navbar para destacar melhor sua presença quando fixa no topo: altera a cor de fundo para vermelho escuro (#b91c1c), deixa o texto e ícones brancos, muda a cor do sublinhado dos links para #f59e42 e aumenta o brilho da logo para maior visibilidade. Ao rolar a página, a navbar retorna à estilização original.